### PR TITLE
fix merge-publish step failure while building docker image

### DIFF
--- a/mongodb-backup/Dockerfile
+++ b/mongodb-backup/Dockerfile
@@ -16,6 +16,8 @@ RUN apk add --update \
   linux-headers \
   musl-dev \
   openssl-dev \
+  rust \
+  cargo \
   && pip install gsutil \
   && apk del build-deps \
   && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Docker build failed with following error message: https://github.com/hypertrace/mongodb/runs/3041530368?check_suite_focus=true#logs
```
  Building wheel for cryptography (PEP 517): started
  Building wheel for cryptography (PEP 517): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 /usr/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py build_wheel /tmp/tmp52i83odm
       cwd: /tmp/pip-install-k39jnyt1/cryptography_3ea562e4bf984fa5962446ec7f339304
  Complete output (165 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.8
  creating build/lib.linux-x86_64-3.8/cryptography
  copying src/cryptography/utils.py -> build/lib.linux-x86_64-3.8/cryptography
  copying src/cryptography/__init__.py -> build/lib.linux-x86_64-3.8/cryptography
  copying src/cryptography/__about__.py -> build/lib.linux-x86_64-3.8/cryptography
  copying src/cryptography/fernet.py -> build/lib.linux-x86_64-3.8/cryptography
  copying src/cryptography/exceptions.py -> build/lib.linux-x86_64-3.8/cryptography
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat
  copying src/cryptography/hazmat/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat
  copying src/cryptography/hazmat/_der.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat
  copying src/cryptography/hazmat/_types.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat
  copying src/cryptography/hazmat/_oid.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat
  creating build/lib.linux-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/general_name.py -> build/lib.linux-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/ocsp.py -> build/lib.linux-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/base.py -> build/lib.linux-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/name.py -> build/lib.linux-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/extensions.py -> build/lib.linux-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/certificate_transparency.py -> build/lib.linux-x86_64-3.8/cryptography/x509
  copying src/cryptography/x509/oid.py -> build/lib.linux-x86_64-3.8/cryptography/x509
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/backends
  copying src/cryptography/hazmat/backends/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends
  copying src/cryptography/hazmat/backends/interfaces.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/bindings
  copying src/cryptography/hazmat/bindings/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/bindings
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/padding.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/poly1305.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/keywrap.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hashes.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_cipheralgorithm.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/constant_time.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hmac.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_serialization.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_asymmetric.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/cmac.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x448.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x25519.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/utils.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/rsa.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x509.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed25519.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/poly1305.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/aead.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hashes.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ec.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dh.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ocsp.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ciphers.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hmac.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/backend.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/encode_asn1.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/cmac.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed448.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dsa.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/decode_asn1.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/backends/openssl
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/_conditional.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/binding.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/bindings/openssl
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x448.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x25519.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/utils.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/rsa.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/padding.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed25519.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ec.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dh.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed448.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dsa.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/asymmetric
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs7.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/base.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs12.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/ssh.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/serialization
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/hkdf.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/x963kdf.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/pbkdf2.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/concatkdf.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/scrypt.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/kbkdf.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/kdf
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/aead.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/base.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/algorithms.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/modes.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/ciphers
  creating build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/utils.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/__init__.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/totp.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/hotp.py -> build/lib.linux-x86_64-3.8/cryptography/hazmat/primitives/twofactor
  running egg_info
  writing src/cryptography.egg-info/PKG-INFO
  writing dependency_links to src/cryptography.egg-info/dependency_links.txt
  writing requirements to src/cryptography.egg-info/requires.txt
  writing top-level names to src/cryptography.egg-info/top_level.txt
  reading manifest file 'src/cryptography.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  no previously-included directories found matching 'docs/_build'
  warning: no previously-included files found matching 'vectors'
  warning: no previously-included files matching '*' found under directory 'vectors'
  warning: no previously-included files matching '*' found under directory '.github'
  warning: no previously-included files found matching 'release.py'
  warning: no previously-included files found matching '.coveragerc'
  warning: no previously-included files found matching 'codecov.yml'
  warning: no previously-included files found matching '.readthedocs.yml'
  warning: no previously-included files found matching 'dev-requirements.txt'
  warning: no previously-included files found matching 'tox.ini'
  warning: no previously-included files found matching 'mypy.ini'
  warning: no previously-included files matching '*' found under directory '.zuul.d'
  warning: no previously-included files matching '*' found under directory '.zuul.playbooks'
  adding license file 'LICENSE'
  adding license file 'LICENSE.APACHE'
  adding license file 'LICENSE.BSD'
  adding license file 'LICENSE.PSF'
  writing manifest file 'src/cryptography.egg-info/SOURCES.txt'
  copying src/cryptography/py.typed -> build/lib.linux-x86_64-3.8/cryptography
  running build_ext
  generating cffi module 'build/temp.linux-x86_64-3.8/_padding.c'
  creating build/temp.linux-x86_64-3.8
  generating cffi module 'build/temp.linux-x86_64-3.8/_openssl.c'
  running build_rust

      =============================DEBUG ASSISTANCE=============================
      If you are seeing a compilation error please try the following steps to
      successfully install cryptography:
      1) Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
      2) Read https://cryptography.io/en/latest/installation.html for specific
         instructions for your platform.
      3) Check our frequently asked questions for more information:
         https://cryptography.io/en/latest/faq.html
      4) Ensure you have a recent Rust toolchain installed:
         https://cryptography.io/en/latest/installation.html#rust
      5) If you are experiencing issues with Rust for *this release only* you may
         set the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1`.
      =============================DEBUG ASSISTANCE=============================

  error: can't find Rust compiler

  If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.

  To update pip, run:

      pip install --upgrade pip

  and then retry package installation.

  If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.

  This package requires Rust >=1.41.0.
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
  Building wheel for retry-decorator (setup.py): started
  Building wheel for retry-decorator (setup.py): finished with status 'done'
  Created wheel for retry-decorator: filename=retry_decorator-1.1.1-py2.py3-none-any.whl size=3642 sha256=f38cc5630f433edfd266f6a5efc80ecd7995749028dc29d942444717948657bd
  Stored in directory: /root/.cache/pip/wheels/1e/bb/cb/5d7a05561d7ec60b8c0dc65f156a33909a3eb5c56340959fa9
  Building wheel for pyu2f (setup.py): started
  Building wheel for pyu2f (setup.py): finished with status 'done'
  Created wheel for pyu2f: filename=pyu2f-0.1.5-py3-none-any.whl size=39387 sha256=dfe38172021e24ac10f9a22677871f5f5f53e3b868844314dcb1823f3e20cc6a
  Stored in directory: /root/.cache/pip/wheels/8d/38/8f/378b4491d760a176f261d56310fcb051e53090a894534acbf0
Successfully built gsutil crcmod gcs-oauth2-boto-plugin retry-decorator pyu2f
Failed to build cryptography
ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
```
