### PR TITLE
update backup job and rename mongodb exporter port name

### DIFF
--- a/helm/templates/backup/cronjob.yaml
+++ b/helm/templates/backup/cronjob.yaml
@@ -37,7 +37,10 @@ spec:
               args:
                 - |
                   finish() {
-                    curl -sf -XPOST http://127.0.0.1:15020/quitquitquit || true
+                    code=$?
+                    curl -s -XPOST http://127.0.0.1:15020/quitquitquit
+                    rm /backup/mongodb*
+                    exit $code
                   }
                   trap finish EXIT
 
@@ -58,7 +61,7 @@ spec:
                   timestamp=$(date +%Y-%m-%d-%H-%M-%S)
                   month=$(date +%Y-%m)
                   BACKUP_LOCATION=gs://$BUCKET/mongodb/$CLUSTER_NAME/$month
-                  mongodump --uri="$MONGODB_URI" --oplog --gzip --archive=/backup/mongodb-${timestamp}.tar.gz || exit 2
+                  mongodump --uri="$MONGODB_URI" {{ if .Values.backup.oplog }} --oplog {{ end }} --gzip --archive=/backup/mongodb-${timestamp}.tar.gz || exit 2
                   gsutil cp "/backup/mongodb-${timestamp}.tar.gz" "$BACKUP_LOCATION/mongodb-${timestamp}.tar.gz" || exit 2
                   rm /backup/mongodb-${timestamp}.tar.gz || exit 0
               env:

--- a/helm/templates/exporter/deployment.yaml
+++ b/helm/templates/exporter/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - --web.listen-address={{ printf ":%s" .Values.exporter.port }}
             {{- toYaml .Values.exporter.extraArgs | nindent 12 }}
           ports:
-            - name: metrics
+            - name: http-metrics
               containerPort: {{ .Values.exporter.port }}
               protocol: TCP
           livenessProbe:

--- a/helm/templates/exporter/service.yaml
+++ b/helm/templates/exporter/service.yaml
@@ -13,9 +13,9 @@ metadata:
 spec:
   ports:
     - port: {{ .Values.exporter.service.port }}
-      targetPort: metrics
+      targetPort: http-metrics
       protocol: TCP
-      name: metrics
+      name: http-metrics
   selector:
     app: {{ include "mongodb-exporter.name" . }}
     release: {{ .Release.Name }}

--- a/helm/templates/exporter/servicemonitor.yaml
+++ b/helm/templates/exporter/servicemonitor.yaml
@@ -17,7 +17,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: http-metrics
       interval: {{ .Values.exporter.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.exporter.serviceMonitor.scrapeTimeout }}
       {{- if .Values.exporter.serviceMonitor.secure }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -190,7 +190,7 @@ exporter:
   livenessProbe:
     httpGet:
       path: /
-      port: metrics
+      port: http-metrics
     initialDelaySeconds: 10
 
   # [mongodb://][user:pass@]host1[:port1][,host2[:port2],...][/database][?options]
@@ -210,7 +210,7 @@ exporter:
   readinessProbe:
     httpGet:
       path: /
-      port: metrics
+      port: http-metrics
     initialDelaySeconds: 10
 
   replicas: 1
@@ -271,6 +271,7 @@ backup:
   imagePullSecrets: []
   mongodb:
     uri: "mongo://mongodb:27017"
+  oplog: false
   cluster: "test"
   gcloud: {}
   affinity: {}


### PR DESCRIPTION
1. update backup job to use --oplog flag based on helm values.
2. Rename mongodb exporter port name for istio explicit protocol selection.