### PR TITLE
Added support for batch/v1 Cronjob API Version

### DIFF
--- a/helm/templates/backup/cronjob.yaml
+++ b/helm/templates/backup/cronjob.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.backup.enabled }}
+{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ include "mongodb.fullname" . }}-backup


### PR DESCRIPTION
## Description
Added a check in helm chart to switch to new Kubernetes API Version of Cronjob

### Testing
deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.
